### PR TITLE
chore: remove large PDF handbooks from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ src-tauri/target/
 ffmpeg.zip
 ffmpeg/
 temp/
+
+# Large binary handbooks (do not commit)
+*.pdf


### PR DESCRIPTION
Removes 3 PDF files totaling ~53MB that bloat the repo:
- handbook/泉州研学手册【对折版】.pdf (48MB)
- handbook/竹子观察手册【PDF】.pdf (2.6MB)
- handbook/suzhou/苏州 研学手册.pdf (612KB)

Adds *.pdf to .gitignore to prevent re-adding.